### PR TITLE
Make the environment accessible through getconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can set your environment to whatever you want, but we color these nicely:
 
     // so you can just use it
     console.log(config.databasePassword); // outputs: "something long and silly"
+    console.log(config.getconfig.env); // outputs the current environment
     ```
 
 4. (optional) You can also config whether you want it to log out it's environment info and whether or not to use colors in output. By adding the following to your `{{some name}}_config.json` file:

--- a/getconfig.js
+++ b/getconfig.js
@@ -41,7 +41,10 @@ try {
     if (config.getconfig) {
         if (config.getconfig.hasOwnProperty('colors')) useColor = config.getconfig.colors;
         if (config.getconfig.hasOwnProperty('silent')) silent = config.getconfig.silent;        
+    } else {
+        config.getconfig = {};
     }
+    config.getconfig.env = env;
 
 } catch (e) {
     console.error(c("Invalid JSON file", 'red'));


### PR DESCRIPTION
Just a convenience thing to prevent modules from having to look up their current environment when getconfig has already done it, instead of

``` js
var env = process.env.NODE_ENV || 'dev';
```

modules can simply refer to config.getconfig.env
