### PR TITLE
Allow a single config.json file

### DIFF
--- a/getconfig.js
+++ b/getconfig.js
@@ -37,28 +37,34 @@ try {
         usingDefault = true;
     } catch (e) {
         console.error(c("No config file found for %s", 'red'), env);
-        console.error(c("We couldn't find anything at: %s", 'grey'), configPath + env + '_config.json');
-        console.error(c("Or at: %s", 'grey'), configPath + 'config.json');
+        console.error(c("We couldn't find %s_config.json or config.json at: %s", 'grey'), env, configPath);
         throw e;
     }
 }
 
 try {
     config = JSON.parse(config);
-    if (usingDefault) config = config[env];
-    if (config.getconfig) {
-        if (config.getconfig.hasOwnProperty('colors')) useColor = config.getconfig.colors;
-        if (config.getconfig.hasOwnProperty('silent')) silent = config.getconfig.silent;        
-    } else {
-        config.getconfig = {};
-    }
-    config.getconfig.env = env;
-
 } catch (e) {
     console.error(c("Invalid JSON file", 'red'));
     console.error(c("Check it at:", 'grey') + c(" http://jsonlint.com", 'blue'));
     throw e;
 }
+
+if (usingDefault) {
+    if (!config.hasOwnProperty(env)) {
+        console.error(c("The config.json file does not have key: '%s'", 'red'), env);
+        throw new Error('Invalid configuration');
+    }
+    config = config[env];
+}
+if (config.getconfig) {
+    if (config.getconfig.hasOwnProperty('colors')) useColor = config.getconfig.colors;
+    if (config.getconfig.hasOwnProperty('silent')) silent = config.getconfig.silent;        
+} else {
+    config.getconfig = {};
+}
+config.getconfig.env = env;
+
 
 // log out what we've got
 if (!silent) console.log(c(c(env, color), 'bold') + c(' environment detected', 'grey'));

--- a/getconfig.js
+++ b/getconfig.js
@@ -37,7 +37,8 @@ try {
         usingDefault = true;
     } catch (e) {
         console.error(c("No config file found for %s", 'red'), env);
-        console.error(c("We couldn't find anything at: %s", 'grey'), configPath);
+        console.error(c("We couldn't find anything at: %s", 'grey'), configPath + env + '_config.json');
+        console.error(c("Or at: %s", 'grey'), configPath + 'config.json');
         throw e;
     }
 }

--- a/getconfig.js
+++ b/getconfig.js
@@ -2,6 +2,7 @@ var fs = require('fs'),
     path = require('path'),
     env = process.env.NODE_ENV || 'dev',
     colors = require('colors'),
+    usingDefault = false,
     useColor = true,
     silent = false,
     color,
@@ -25,19 +26,25 @@ function c(str, color) {
 }
 
 // build a file path to the config
-configPath = (require.main ? path.dirname(require.main.filename) : ".") + '/' + env + '_config.json';
+configPath = (require.main ? path.dirname(require.main.filename) : ".") + '/';
 
 // try to read it
 try {
-    config = fs.readFileSync(configPath, 'utf-8');
+    config = fs.readFileSync(configPath + env + '_config.json', 'utf-8');
 } catch (e) {
-    console.error(c("No config file found for %s", 'red'), env);
-    console.error(c("We couldn't find anything at: %s", 'grey'), configPath);
-    throw e;
+    try {
+        config = fs.readFileSync(configPath + 'config.json', 'utf-8');
+        usingDefault = true;
+    } catch (e) {
+        console.error(c("No config file found for %s", 'red'), env);
+        console.error(c("We couldn't find anything at: %s", 'grey'), configPath);
+        throw e;
+    }
 }
 
 try {
     config = JSON.parse(config);
+    if (usingDefault) config = config[env];
     if (config.getconfig) {
         if (config.getconfig.hasOwnProperty('colors')) useColor = config.getconfig.colors;
         if (config.getconfig.hasOwnProperty('silent')) silent = config.getconfig.silent;        


### PR DESCRIPTION
The idea behind this is to allow for several static environments to be configured in one file. If an env_config.json file exists, it will be used first. If not, check for a config.json and see if it has the key 'env'. If the key exists, use that as the config object. If the key doesn't exist, throw an error.

config.json
```js
{
  "dev": {
    "isDev": true
  },
  "test": {
    "isDev": false,
    "isTest": true
  }
}
```