### PR TITLE
Changed how configPath is found.

### DIFF
--- a/getconfig.js
+++ b/getconfig.js
@@ -22,7 +22,7 @@ function c(str, color) {
 }
 
 // build a file path to the config
-configPath = (require.main ? path.dirname(require.main.filename) : ".") + path.sep + env + '_config.json';
+configPath = __dirname.split('node_modules')[0] + env + '_config.json';
 
 // try to read it
 try {


### PR DESCRIPTION
I ran into the issue where this module wasn't working for test suites like Jasmine. For example, if you run `jasmine-node spec` you would get the wrong file path and a silly error about `test_config.json` not being found.

I also improved the readability of how color is chosen based on environment. Switch statements FTW!
