### PR TITLE
Add GETCONFIG_ROOT override to set the location of config files explicitly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,14 @@ You can set your environment to whatever you want, but we color these nicely:
     }
     ```
 
+
 ### Extra
 
 getconfig will also fill in the `getconfig.env` value with the current environment name so you can programatically determine the environment if you'd like.
+
+### Gotchas
+
+In certain circumstances, when your app isn't run directly (e.g. test runners) getconfig may not be able to lookup your config file properly. In this case, set the GETCONFIG\_ROOT environment variable to directory where your configs are held.
 
 ### License
 

--- a/getconfig.js
+++ b/getconfig.js
@@ -6,6 +6,7 @@ var fs = require('fs'),
     silent = false,
     color,
     config,
+    configRoot,
     configPath;
 
 // set our color based on environment
@@ -25,7 +26,8 @@ function c(str, color) {
 }
 
 // build a file path to the config
-configPath = (require.main ? path.dirname(require.main.filename) : ".") + path.sep + env + '_config.json';
+configRoot = process.env.GETCONFIG_ROOT || (require.main ? path.dirname(require.main.filename) : ".");
+configPath = configRoot + path.sep + env + '_config.json';
 
 // try to read it
 try {

--- a/package.json
+++ b/package.json
@@ -12,5 +12,11 @@
     "main": "getconfig.js",
     "dependencies": {
         "colors": ""
+    },
+    "devDependencies": {
+        "tape": "~2.3.0"
+    },
+    "scripts": {
+        "test": "node tests/tests.js"
     }
 }

--- a/tests/nonroot/app.js
+++ b/tests/nonroot/app.js
@@ -1,0 +1,16 @@
+var config = require('../../getconfig.js');
+
+var assert = require('assert');
+var NODE_ENV = process.env.NODE_ENV || 'dev';
+
+if (NODE_ENV === 'dev') {
+    assert.equal(config.getconfig.env, 'dev');
+    assert.equal(config.testValue, 'dev-value');
+}
+
+if (NODE_ENV === 'test') {
+    assert.equal(config.getconfig.env, 'test');
+    assert.equal(config.testValue, 'test-value');
+}
+
+console.log('All tests passed');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,0 +1,24 @@
+var exec = require('child_process').exec;
+var path = require('path');
+var test = require('tape');
+
+
+
+// Test normal use case
+test('It should import properly when require.main is the config root', function (test) {
+    exec('NODE_ENV=dev node ' + path.join(__dirname, 'typical', 'app.js'), function (err, stdout, stderr) {
+        test.assert(!err);
+        test.end();
+    });
+});
+
+
+
+// Test normal use case
+test('It should import properly when require.main is not the config root but GETCONFIG_ROOT is set', function (test) {
+    var config_path = path.join(__dirname, 'typical');
+    exec('GETCONFIG_ROOT=' + config_path + ' NODE_ENV=dev node ' + path.join(__dirname, 'nonRoot', 'app.js'), function (err, stdout, stderr) {
+        test.assert(!err);
+        test.end();
+    });
+});

--- a/tests/typical/app.js
+++ b/tests/typical/app.js
@@ -1,0 +1,16 @@
+var config = require('../../getconfig.js');
+
+var assert = require('assert');
+var NODE_ENV = process.env.NODE_ENV || 'dev';
+
+if (NODE_ENV === 'dev') {
+    assert.equal(config.getconfig.env, 'dev');
+    assert.equal(config.testValue, 'dev-value');
+}
+
+if (NODE_ENV === 'test') {
+    assert.equal(config.getconfig.env, 'test');
+    assert.equal(config.testValue, 'test-value');
+}
+
+console.log('All tests passed');

--- a/tests/typical/dev_config.json
+++ b/tests/typical/dev_config.json
@@ -1,0 +1,3 @@
+{
+    "testValue": "dev-value"
+}

--- a/tests/typical/test_config.json
+++ b/tests/typical/test_config.json
@@ -1,0 +1,3 @@
+{
+    "testValue": "test-value"
+}


### PR DESCRIPTION
This is required when using a test-runner, or other
situation where require.main doesn't end up being 
the "main" app file.

Also, tests.
