### PR TITLE
Exclude `tests` directory bloat from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "tape": "~2.3.0"
   },
+  "files": [
+    "getconfig.js"
+  ],
   "main": "getconfig.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`package.json` and `README` are automatically included, per https://docs.npmjs.com/files/package.json#files